### PR TITLE
Fix padding on SecondsToTimestamp

### DIFF
--- a/deepgram/transcriptions.go
+++ b/deepgram/transcriptions.go
@@ -172,5 +172,5 @@ func SecondsToTimestamp(seconds float64) string {
 	hours := int(seconds / 3600)
 	minutes := int((seconds - float64(hours*3600)) / 60)
 	seconds = seconds - float64(hours*3600) - float64(minutes*60)
-	return fmt.Sprintf("%02d:%02d:%02.3f", hours, minutes, seconds)
+	return fmt.Sprintf("%02d:%02d:%06.3f", hours, minutes, seconds)
 }


### PR DESCRIPTION
## Proposed changes
Solves: https://github.com/deepgram-devs/deepgram-go-sdk/issues/27

Timestamps under 10 seconds render as: `00:00:1.814`, and should be `00:00:01.814` according to the [WebVTT Spec](https://www.w3.org/TR/webvtt1/#webvtt-timestamp):

> 4. Two [ASCII digits](https://www.w3.org/TR/html51/infrastructure.html#ascii-digits), representing the seconds as a base ten integer in the range 0 ≤ seconds ≤ 59.

Go's float formatting requires you specify the _total_ number of digits as the first number (including the decimal point) and the decimal precision as the second number:

```
return fmt.Sprintf("%02d:%02d:%02.3f", hours, minutes, seconds)
```

Should be:

```
return fmt.Sprintf("%02d:%02d:%06.3f", hours, minutes, seconds)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
