### PR TITLE
updates readme to be more accurate for Local Installation and Example…

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ git clone https://github.com/deepgram-devs/deepgram-go-sdk/
 ```
 cd deepgram-go-sdk
 
-go get .
+cd deepgram
+
+go get
 ```
 
 - Add the API key in the `examples/liveTranscription_example.go` file:
@@ -55,7 +57,6 @@ dg := *deepgram.NewClient("YOUR_API_KEY")
 ```
 go run examples/liveTranscription_example.go
 ```
-
 
 ## Getting Help
 


### PR DESCRIPTION
## Proposed changes

There is a missing step when doing the Local Installation and Example Set up in the readme. I have added the missing step, which is to cd into the deepgram folder and then install the packages.