### PR TITLE
fix the install instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can learn more about the full Deepgram API at [https://developers.deepgram.c
 # Installation
 
 ```bash
-go get https://github.com/deepgram-devs/deepgram-go-sdk
+go get github.com/deepgram-devs/deepgram-go-sdk
 ```
 
 # Requirements


### PR DESCRIPTION
## Proposed changes
The instruction `go get https://github.com/deepgram-devs/deepgram-go-sdk` is incorrect. Because `http://` is not allowed as a go mod link.


## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
