### PR TITLE
change to User-Agent header

### DIFF
--- a/deepgram/deepgram.go
+++ b/deepgram/deepgram.go
@@ -3,10 +3,13 @@ package deepgram
 import (
 	"encoding/json"
 	"net/http"
+	"runtime"
+	"strings"
 )
 
 var sdkVersion string = "0.10.0"
-var dgAgent string = "deepgram-go-sdk/v" + sdkVersion
+
+var dgAgent string = "@deepgram/sdk/" + sdkVersion + " go/" + goVersion()
 
 type Client struct {
 	ApiKey            string
@@ -43,4 +46,12 @@ func GetJson(resp *http.Response, target interface{}) error {
 	defer resp.Body.Close()
 
 	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func goVersion() string {
+	version := runtime.Version()
+	if strings.HasPrefix(version, "go") {
+		return version[2:]
+	}
+	return version
 }

--- a/deepgram/prerecorded.go
+++ b/deepgram/prerecorded.go
@@ -51,13 +51,13 @@ type PreRecordedTranscriptionOptions struct {
 	Utterances         bool        `json:"utterances" url:"utterances,omitempty" `
 	Utt_split          float64     `json:"utt_split" url:"utt_split,omitempty" `
 	Version            string      `json:"version" url:"version,omitempty" `
-	FillerWords      string   `json:"filler_words" url:"filler_words,omitempty" `
+	FillerWords        string      `json:"filler_words" url:"filler_words,omitempty" `
 }
 
 type PreRecordedResponse struct {
-	Request_id string `json:"request_id,omitempty"`
-	Metadata Metadata `json:"metadata"`
-	Results  Results  `json:"results"`
+	Request_id string   `json:"request_id,omitempty"`
+	Metadata   Metadata `json:"metadata"`
+	Results    Results  `json:"results"`
 }
 
 type Metadata struct {
@@ -203,7 +203,7 @@ func (dg *Client) PreRecordedFromStream(source ReadStreamSource, options PreReco
 		"Host":          []string{dg.Host},
 		"Content-Type":  []string{source.Mimetype},
 		"Authorization": []string{"token " + dg.ApiKey},
-		"X-DG-Agent":    []string{dgAgent},
+		"User-Agent":    []string{dgAgent},
 	}
 
 	res, err := client.Do(req)
@@ -246,7 +246,7 @@ func (dg *Client) PreRecordedFromURL(source UrlSource, options PreRecordedTransc
 		"Host":          []string{dg.Host},
 		"Content-Type":  []string{"application/json"},
 		"Authorization": []string{"token " + dg.ApiKey},
-		"X-DG-Agent":    []string{dgAgent},
+		"User-Agent":    []string{dgAgent},
 	}
 
 	var result PreRecordedResponse

--- a/deepgram/transcriptions.go
+++ b/deepgram/transcriptions.go
@@ -52,7 +52,7 @@ func (dg *Client) LiveTranscription(options LiveTranscriptionOptions) (*websocke
 	header := http.Header{
 		"Host":          []string{dg.Host},
 		"Authorization": []string{"token " + dg.ApiKey},
-		"X-DG-Agent":    []string{dgAgent},
+		"User-Agent":    []string{dgAgent},
 	}
 
 	c, resp, err := websocket.DefaultDialer.Dial(u.String(), header)


### PR DESCRIPTION
Change `X-DG-Agent` header to `User-Agent`. `dgAgent` now have the following format `@deepgram/sdk/{sdkVersion} go/{goVersion}`