### PR TITLE
Encapsulate the Live/Stream Object to Hide Internal Details

### DIFF
--- a/examples/streaming/main.go
+++ b/examples/streaming/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -13,9 +14,7 @@ import (
 	"reflect"
 	"time"
 
-	gabs "github.com/Jeffail/gabs/v2"
-	"github.com/dvonthenen/websocket"
-
+	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
 	client "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/live"
 )
 
@@ -26,73 +25,53 @@ const (
 )
 
 func main() {
-	var deepgramApiKey string
-	if v := os.Getenv("DEEPGRAM_API_KEY"); v != "" {
-		log.Println("DEEPGRAM_API_KEY found")
-		deepgramApiKey = v
-	} else {
-		log.Fatal("DEEPGRAM_API_KEY not found")
-		os.Exit(1)
-	}
+	// context
+	ctx := context.Background()
 
-	// HTTP client
-	httpClient := new(http.Client)
-
-	res, err := httpClient.Get(STREAM_URL)
-	if err != nil {
-		log.Println("ERROR getting stream", err)
-		return
-	}
-	defer res.Body.Close()
-
-	fmt.Println("Stream is up and running ", reflect.TypeOf(res))
-
-	reader := bufio.NewReader(res.Body)
-
-	// live transcription
-	liveTranscriptionOptions := client.LiveTranscriptionOptions{
+	// options
+	transcriptOptions := interfaces.LiveTranscriptionOptions{
 		Language:  "en-US",
 		Punctuate: true,
 	}
 
-	dgConn, _, err := client.New(deepgramApiKey, liveTranscriptionOptions)
+	dgClient, err := client.NewWithDefaults(ctx, transcriptOptions)
 	if err != nil {
 		log.Println("ERROR creating LiveTranscription connection:", err)
 		return
 	}
-	defer dgConn.Close()
 
-	// process messages
-	chunk := make([]byte, CHUNK_SIZE)
+	// call connect!
+	wsconn := dgClient.Connect()
+	if wsconn == nil {
+		log.Println("Client.Connect failed")
+		os.Exit(1)
+	}
+
+	// feed the stream to the websocket
+	httpClient := new(http.Client)
+
+	res, err := httpClient.Get(STREAM_URL)
+	if err != nil {
+		log.Printf("httpClient.Get failed. Err: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Stream is up and running %s\n", reflect.TypeOf(res))
+
+	// this is a blocking call...
 	go func() {
-		for {
-			_, message, err := dgConn.ReadMessage()
-			if err != nil {
-				log.Println("ERROR reading message:", err)
-				return
-			}
-
-			jsonParsed, jsonErr := gabs.ParseJSON(message)
-			if jsonErr != nil {
-				log.Println("ERROR parsing JSON message:", err)
-				return
-			}
-			log.Printf("recv: %s", jsonParsed.Path("channel.alternatives.0.transcript").String())
-		}
+		dgClient.Stream(bufio.NewReader(res.Body))
 	}()
 
-	for {
-		bytesRead, err := reader.Read(chunk)
+	fmt.Print("Press ENTER to exit!\n\n")
+	input := bufio.NewScanner(os.Stdin)
+	input.Scan()
 
-		if err != nil {
-			log.Println("ERROR reading chunk:", err)
-			return
-		}
-		err = dgConn.WriteMessage(websocket.BinaryMessage, chunk[:bytesRead])
-		if err != nil {
-			log.Println("ERROR writing message:", err)
-			return
-		}
-		time.Sleep(TEN_MILLISECONDS_SLEEP)
-	}
+	// close HTTP stream
+	res.Body.Close()
+
+	// close client
+	dgClient.Stop()
+
+	fmt.Printf("Succeeded!\n\n")
 }

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,11 @@ require (
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 )
 
-require github.com/dvonthenen/websocket v1.5.1-dyv.2 // indirect
+require (
+	github.com/dvonthenen/websocket v1.5.1-dyv.2 // indirect
+	github.com/fatih/color v1.15.0 // indirect
+	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
+	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.17 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Jeffail/gabs/v2 v2.7.0 h1:Y2edYaTcE8ZpRsR2AtmPu5xQdFDIthFG0jYhu5PY8kg
 github.com/Jeffail/gabs/v2 v2.7.0/go.mod h1:dp5ocw1FvBBQYssgHsG7I1WYsiLRtkUaB1FEtSwvNUw=
 github.com/dvonthenen/websocket v1.5.1-dyv.2 h1:OXlWJJkeHt8k4+MEI0Y8SQjY2ihHYD2z/tI7sZZfsnA=
 github.com/dvonthenen/websocket v1.5.1-dyv.2/go.mod h1:q2GbopbpFJvBP4iqVvqwwahVmvu2HnCfdqCWDoQVKMM=
+github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
+github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -11,8 +13,18 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f h1:7LYC+Yfkj3CTRcShK0KOL/w6iTiKyqqBA9a41Wnggw8=
+github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
 github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
 github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
+github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
+github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
+github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=

--- a/pkg/api/live/v1/constants.go
+++ b/pkg/api/live/v1/constants.go
@@ -1,0 +1,15 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package live
+
+import "errors"
+
+var (
+	// ErrInvalidMessageType invalid message type
+	ErrInvalidMessageType = errors.New("invalid message type")
+
+	// ErrUserCallbackNotDefined user callback object not defined
+	ErrUserCallbackNotDefined = errors.New("user callback object not defined")
+)

--- a/pkg/api/live/v1/default.go
+++ b/pkg/api/live/v1/default.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package live
+
+import (
+
+	// prettyjson "github.com/hokaccha/go-prettyjson"
+
+	"log"
+	"strings"
+
+	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+)
+
+type DefaultCallbackHandler struct {
+	sb strings.Builder
+}
+
+func (dch DefaultCallbackHandler) Message(mr *interfaces.MessageResponse) error {
+	// DEBUG: just print the transcription
+	// data, err := json.Marshal(mr)
+	// if err != nil {
+	// 	log.Printf("RecognitionResult json.Marshal failed. Err: %v\n", err)
+	// 	return err
+	// }
+
+	// prettyJson, err := prettyjson.Format(data)
+	// if err != nil {
+	// 	log.Printf("prettyjson.Marshal failed. Err: %v\n", err)
+	// 	return err
+	// }
+	// log.Printf("\n\nMessage Object:\n%s\n\n", prettyJson)
+
+	// Only print the final transcript
+	// // handle the message
+	// sentence := strings.TrimSpace(mr.Channel.Alternatives[0].Transcript)
+
+	// if len(mr.Channel.Alternatives) == 0 || len(sentence) == 0 {
+	// 	// klog.V(7).Infof("DEEPGRAM - no transcript")
+	// 	return nil
+	// }
+
+	// isFinal := mr.SpeechFinal
+	// sentence = strings.ToLower(sentence)
+	// dch.sb.WriteString(sentence)
+
+	// // // debug
+	// // klog.V(4).Infof("transcription result: text = %s, final = %t", i.sb.String(), isFinal)
+
+	// if !isFinal {
+	// 	// klog.V(7).Infof("DEEPGRAM - not final")
+	// 	return nil
+	// }
+
+	// // debug
+	// log.Printf("Deepgram transcription: text = %s, final = %t", dch.sb.String(), isFinal)
+	// dch.sb.Reset()
+
+	// handle the message
+	sentence := strings.TrimSpace(mr.Channel.Alternatives[0].Transcript)
+
+	if len(mr.Channel.Alternatives) == 0 || len(sentence) == 0 {
+		// klog.V(7).Infof("DEEPGRAM - no transcript")
+		return nil
+	}
+	log.Printf("%s\n", sentence)
+
+	return nil
+}
+
+func NewDefaultCallbackHandler() DefaultCallbackHandler {
+	return DefaultCallbackHandler{}
+}

--- a/pkg/api/live/v1/interfaces/constants.go
+++ b/pkg/api/live/v1/interfaces/constants.go
@@ -1,0 +1,13 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+const (
+	// message types
+	TypeMessageResponse string = "Results"
+
+	// Error type
+	TypeErrorResponse string = "Error"
+)

--- a/pkg/api/live/v1/interfaces/interfaces.go
+++ b/pkg/api/live/v1/interfaces/interfaces.go
@@ -1,0 +1,11 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+// LiveMessageCallback is a callback used to receive notifcations for platforms messages
+type LiveMessageCallback interface {
+	Message(mr *MessageResponse) error
+	// TODO: implement other conversation insights
+}

--- a/pkg/api/live/v1/interfaces/types.go
+++ b/pkg/api/live/v1/interfaces/types.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+/*
+Shared defintions for the Deepgram API
+*/
+type Words struct {
+	Confidence     float64 `json:"confidence,omitempty"`
+	End            float64 `json:"end,omitempty"`
+	PunctuatedWord string  `json:"punctuated_word,omitempty"`
+	Start          float64 `json:"start,omitempty"`
+	Word           string  `json:"word,omitempty"`
+}
+type Alternatives struct {
+	Confidence float64 `json:"confidence,omitempty"`
+	Transcript string  `json:"transcript,omitempty"`
+	Words      []Words `json:"words,omitempty"`
+}
+type Channel struct {
+	Alternatives []Alternatives `json:"alternatives,omitempty"`
+}
+
+type ModelInfo struct {
+	Arch    string `json:"arch,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+}
+type Metadata struct {
+	ModelInfo ModelInfo `json:"model_info,omitempty"`
+	ModelUUID string    `json:"model_uuid,omitempty"`
+	RequestID string    `json:"request_id,omitempty"`
+}
+
+/*
+Results from Live Transcription
+*/
+type MessageResponse struct {
+	Channel      Channel  `json:"channel,omitempty"`
+	ChannelIndex []int    `json:"channel_index,omitempty"`
+	Duration     float64  `json:"duration,omitempty"`
+	IsFinal      bool     `json:"is_final,omitempty"`
+	Metadata     Metadata `json:"metadata,omitempty"`
+	SpeechFinal  bool     `json:"speech_final,omitempty"`
+	Start        float64  `json:"start,omitempty"`
+	Type         string   `json:"type,omitempty"`
+}
+
+type ErrorResponse struct {
+	Description string `json:"description"`
+	Message     string `json:"message"`
+	Type        string `json:"type"`
+	Variant     string `json:"variant"`
+}

--- a/pkg/api/live/v1/router.go
+++ b/pkg/api/live/v1/router.go
@@ -1,0 +1,138 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package live
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+
+	prettyjson "github.com/hokaccha/go-prettyjson"
+
+	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+)
+
+// MessageRouter is helper struct that routes events
+type MessageRouter struct {
+	callback interfaces.LiveMessageCallback
+}
+
+// NewWithDefault creates a default MessageRouter
+func NewWithDefault() *MessageRouter {
+	return New(NewDefaultCallbackHandler())
+}
+
+// New creates a MessageRouter with user defined callback
+func New(callback interfaces.LiveMessageCallback) *MessageRouter {
+	return &MessageRouter{
+		callback: callback,
+	}
+}
+
+// Message handles platform messages
+func (r *MessageRouter) Message(byMsg []byte) error {
+	// log.Printf("MessageRouter::Message ENTER\n")
+
+	// what is the high level message here?
+	var mt MessageType
+	err := json.Unmarshal(byMsg, &mt)
+	if err != nil {
+		log.Printf("MessageRouter json.Unmarshal(MessageType) failed. Err: %v\n", err)
+		log.Printf("MessageRouter LEAVE\n")
+		return err
+	}
+
+	switch mt.Type {
+	case interfaces.TypeErrorResponse:
+		return r.HandleError(byMsg)
+	case interfaces.TypeMessageResponse:
+		return r.MessageResponse(byMsg)
+	default:
+		return r.UnhandledMessage(byMsg)
+	}
+
+	return nil
+}
+
+// MessageResponse handles the MessageResponse message
+func (r *MessageRouter) MessageResponse(byMsg []byte) error {
+	// log.Printf("MessageResponse ENTER\n")
+
+	// trace debugging
+	// r.printDebugMessages("MessageResponse", byMsg)
+
+	var mr interfaces.MessageResponse
+	err := json.Unmarshal(byMsg, &mr)
+	if err != nil {
+		log.Printf("MessageResponse json.Unmarshal failed. Err: %v\n", err)
+		log.Printf("MessageResponse LEAVE\n")
+		return err
+	}
+
+	if r.callback != nil {
+		err := r.callback.Message(&mr)
+		if err != nil {
+			log.Printf("callback.MessageResponse failed. Err: %v\n", err)
+			// } else {
+			// 	log.Printf("callback.MessageResponse succeeded\n")
+		}
+		// log.Printf("MessageResponse LEAVE\n")
+		return err
+	}
+
+	// log.Printf("User callback is undefined\n")
+	// log.Printf("MessageResponse LEAVE\n")
+	return ErrUserCallbackNotDefined
+}
+
+// HandleError handles error messages
+func (r *MessageRouter) HandleError(byMsg []byte) error {
+	log.Printf("HandleError ENTER\n")
+
+	// trace debugging
+	r.printDebugMessages("HandleError", byMsg)
+
+	var er interfaces.ErrorResponse
+	err := json.Unmarshal(byMsg, &er)
+	if err != nil {
+		log.Printf("HandleError json.Unmarshal failed. Err: %v\n", err)
+		log.Printf("HandleError LEAVE\n")
+		return err
+	}
+
+	b, err := json.MarshalIndent(er, "", "    ")
+	if err != nil {
+		log.Printf("HandleError MarshalIndent failed. Err: %v\n", err)
+		log.Printf("HandleError LEAVE\n")
+		return err
+	}
+
+	log.Printf("\n\nError: %s\n\n", string(b))
+	log.Printf("HandleError LEAVE\n")
+	return errors.New(string(b))
+}
+
+// UnhandledMessage handles the UnhandledMessage message
+func (r *MessageRouter) UnhandledMessage(byMsg []byte) error {
+	log.Printf("UnhandledMessage ENTER\n")
+
+	// trace debugging
+	r.printDebugMessages("UnhandledMessage", byMsg)
+
+	log.Printf("User callback is undefined\n")
+	log.Printf("UnhandledMessage LEAVE\n")
+	return ErrInvalidMessageType
+}
+
+func (r *MessageRouter) printDebugMessages(function string, byMsg []byte) {
+	prettyJson, err := prettyjson.Format(byMsg)
+	if err != nil {
+		log.Printf("prettyjson.Marshal failed. Err: %v\n", err)
+	}
+
+	log.Printf("\n\n-----------------------------------------------\n")
+	log.Printf("%s RAW:\n%s\n", function, prettyJson)
+	log.Printf("-----------------------------------------------\n\n\n")
+}

--- a/pkg/api/live/v1/types.go
+++ b/pkg/api/live/v1/types.go
@@ -1,0 +1,19 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package live
+
+// MessageType is the header to bootstrap you way unmarshalling other messages
+/*
+	Example:
+	{
+		"type": "message",
+		"message": {
+			...
+		}
+	}
+*/
+type MessageType struct {
+	Type string `json:"type"`
+}

--- a/pkg/client/interfaces/constants.go
+++ b/pkg/client/interfaces/constants.go
@@ -1,0 +1,10 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+// API constants
+const (
+	sdkVersion string = "v1.0.0"
+)

--- a/pkg/client/interfaces/types-stream.go
+++ b/pkg/client/interfaces/types-stream.go
@@ -1,0 +1,40 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+type LiveTranscriptionOptions struct {
+	Alternatives     int      `json:"alternatives" url:"alternatives,omitempty" `
+	Callback         string   `json:"callback" url:"callback,omitempty" `
+	Channels         int      `json:"channels" url:"channels,omitempty" `
+	Dates            bool     `json:"dates" url:"dates,omitempty"` // Indicates whether to convert dates from written format (e.g., january first) to numerical format (e.g., 01-01).
+	Diarize          bool     `json:"diarize" url:"diarize,omitempty" `
+	Diarize_version  string   `json:"diarize_version" url:"diarize_version,omitempty" `
+	Dictation        bool     `json:"dictation" url:"dictation,omitempty"` // Option to format punctuated commands. Eg: "i went to the store period new paragraph then i went home" --> "i went to the store. <\n> then i went home"
+	Encoding         string   `json:"encoding" url:"encoding,omitempty" `
+	Endpointing      string   `json:"endpointing" url:"endpointing,omitempty" ` // Can be "false" to disable endpointing, or can be the milliseconds of silence to wait before returning a transcript. Default is 10 milliseconds. Is string here so it can accept "false" as a value.
+	Interim_results  bool     `json:"interim_results" url:"interim_results,omitempty" `
+	Keywords         []string `json:"keywords" url:"keywords,omitempty" `
+	KeywordBoost     string   `json:"keyword_boost" url:"keyword_boost,omitempty" `
+	Language         string   `json:"language" url:"language,omitempty" `
+	Measurements     bool     `json:"measurements" url:"measurements,omitempty" `
+	Model            string   `json:"model" url:"model,omitempty" `
+	Multichannel     bool     `json:"multichannel" url:"multichannel,omitempty" `
+	Ner              bool     `json:"ner" url:"ner,omitempty" `
+	Numbers          bool     `json:"numbers" url:"numbers,omitempty" `
+	Numerals         bool     `json:"numerals" url:"numerals,omitempty" `
+	Profanity_filter bool     `json:"profanity_filter" url:"profanity_filter,omitempty" `
+	Punctuate        bool     `json:"punctuate" url:"punctuate,omitempty" `
+	Redact           bool     `json:"redact" url:"redact,omitempty" `
+	Replace          string   `json:"replace" url:"replace,omitempty" `
+	Sample_rate      int      `json:"sample_rate" url:"sample_rate,omitempty" `
+	Search           []string `json:"search" url:"search,omitempty" `
+	Smart_format     bool     `json:"smart_format" url:"smart_format,omitempty" `
+	Tag              []string `json:"tag" url:"tag,omitempty" `
+	Tier             string   `json:"tier" url:"tier,omitempty" `
+	Times            bool     `json:"times" url:"times,omitempty" `
+	Vad_turnoff      int      `json:"vad_turnoff" url:"vad_turnoff,omitempty" `
+	Version          string   `json:"version" url:"version,omitempty" `
+	FillerWords      string   `json:"filler_words" url:"filler_words,omitempty" `
+}

--- a/pkg/client/interfaces/utils.go
+++ b/pkg/client/interfaces/utils.go
@@ -1,0 +1,75 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package interfaces
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"runtime"
+	"strings"
+)
+
+// connection agent
+var DgAgent string = "@deepgram/sdk/" + sdkVersion + " go/" + goVersion()
+
+func goVersion() string {
+	version := runtime.Version()
+	if strings.HasPrefix(version, "go") {
+		return version[2:]
+	}
+	return version
+}
+
+/*
+	custom headers and configuration options
+*/
+// Signer callback for the certificant signer
+type Signer interface {
+	SignRequest(*http.Request) error
+}
+
+// SignerContext blackbox of data
+type SignerContext struct{}
+
+// WithSigner appends a signer to the given context
+func WithSigner(ctx context.Context, s Signer) context.Context {
+	return context.WithValue(ctx, SignerContext{}, s)
+}
+
+// HeadersContext blackbox of data
+type HeadersContext struct{}
+
+// WithCustomHeaders appends a header to the given context
+func WithCustomHeaders(ctx context.Context, headers http.Header) context.Context {
+	return context.WithValue(ctx, HeadersContext{}, headers)
+}
+
+// ParametersContext blackbox of data
+type ParametersContext struct{}
+
+// WithCustomParameters
+func WithCustomParameters(ctx context.Context, params map[string][]string) context.Context {
+	return context.WithValue(ctx, ParametersContext{}, params)
+}
+
+/*
+RawResponse may be used with the Do method as the resBody argument in order
+to capture the raw response data.
+*/
+type RawResponse struct {
+	bytes.Buffer
+}
+
+// StatusError captures a REST error in the library
+type StatusError struct {
+	Resp *http.Response
+}
+
+// Error string representation for a given error
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%s %s: %s", e.Resp.Request.Method, e.Resp.Request.URL, e.Resp.Status)
+}

--- a/pkg/client/live/client.go
+++ b/pkg/client/live/client.go
@@ -5,86 +5,377 @@
 package live
 
 import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
-	"runtime"
-	"strings"
+	"os"
+	"time"
 
+	// gabs "github.com/Jeffail/gabs/v2"
 	"github.com/dvonthenen/websocket"
 	"github.com/google/go-querystring/query"
+
+	live "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1"
+	msginterfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
 )
 
-type LiveTranscriptionOptions struct {
-	Host             string
-	Alternatives     int      `json:"alternatives" url:"alternatives,omitempty" `
-	Callback         string   `json:"callback" url:"callback,omitempty" `
-	Channels         int      `json:"channels" url:"channels,omitempty" `
-	Dates            bool     `json:"dates" url:"dates,omitempty"` // Indicates whether to convert dates from written format (e.g., january first) to numerical format (e.g., 01-01).
-	Diarize          bool     `json:"diarize" url:"diarize,omitempty" `
-	Diarize_version  string   `json:"diarize_version" url:"diarize_version,omitempty" `
-	Dictation        bool     `json:"dictation" url:"dictation,omitempty"` // Option to format punctuated commands. Eg: "i went to the store period new paragraph then i went home" --> "i went to the store. <\n> then i went home"
-	Encoding         string   `json:"encoding" url:"encoding,omitempty" `
-	Endpointing      string   `json:"endpointing" url:"endpointing,omitempty" ` // Can be "false" to disable endpointing, or can be the milliseconds of silence to wait before returning a transcript. Default is 10 milliseconds. Is string here so it can accept "false" as a value.
-	Interim_results  bool     `json:"interim_results" url:"interim_results,omitempty" `
-	Keywords         []string `json:"keywords" url:"keywords,omitempty" `
-	KeywordBoost     string   `json:"keyword_boost" url:"keyword_boost,omitempty" `
-	Language         string   `json:"language" url:"language,omitempty" `
-	Measurements     bool     `json:"measurements" url:"measurements,omitempty" `
-	Model            string   `json:"model" url:"model,omitempty" `
-	Multichannel     bool     `json:"multichannel" url:"multichannel,omitempty" `
-	Ner              bool     `json:"ner" url:"ner,omitempty" `
-	Numbers          bool     `json:"numbers" url:"numbers,omitempty" `
-	Numerals         bool     `json:"numerals" url:"numerals,omitempty" `
-	Profanity_filter bool     `json:"profanity_filter" url:"profanity_filter,omitempty" `
-	Punctuate        bool     `json:"punctuate" url:"punctuate,omitempty" `
-	Redact           bool     `json:"redact" url:"redact,omitempty" `
-	Replace          string   `json:"replace" url:"replace,omitempty" `
-	Sample_rate      int      `json:"sample_rate" url:"sample_rate,omitempty" `
-	Search           []string `json:"search" url:"search,omitempty" `
-	Smart_format     bool     `json:"smart_format" url:"smart_format,omitempty" `
-	Tag              []string `json:"tag" url:"tag,omitempty" `
-	Tier             string   `json:"tier" url:"tier,omitempty" `
-	Times            bool     `json:"times" url:"times,omitempty" `
-	Vad_turnoff      int      `json:"vad_turnoff" url:"vad_turnoff,omitempty" `
-	Version          string   `json:"version" url:"version,omitempty" `
-	FillerWords      string   `json:"filler_words" url:"filler_words,omitempty" `
+func NewWithDefaults(ctx context.Context, options interfaces.LiveTranscriptionOptions) (*Client, error) {
+	creds := Credentials{}
+	return New(ctx, &creds, options, nil)
 }
 
-var sdkVersion string = "0.10.0"
-var dgAgent string = "@deepgram/sdk/" + sdkVersion + " go/" + goVersion()
-
-func goVersion() string {
-	version := runtime.Version()
-	if strings.HasPrefix(version, "go") {
-		return version[2:]
+// New create new websocket connection
+func New(ctx context.Context, creds *Credentials, options interfaces.LiveTranscriptionOptions, callback msginterfaces.LiveMessageCallback) (*Client, error) {
+	if creds.Host == "" {
+		creds.Host = "api.deepgram.com"
 	}
-	return version
-}
-
-func New(apiKey string, options LiveTranscriptionOptions) (*websocket.Conn, *http.Response, error) {
-	if options.Host == "" {
-		options.Host = "api.deepgram.com"
-	}
-
-	query, _ := query.Values(options)
-	u := url.URL{Scheme: "wss", Host: options.Host, Path: "/v1/listen", RawQuery: query.Encode()}
-	log.Printf("connecting to %s", u.String())
-
-	header := http.Header{
-		"Host":          []string{options.Host},
-		"Authorization": []string{"token " + apiKey},
-		"User-Agent":    []string{dgAgent},
-	}
-
-	c, resp, err := websocket.DefaultDialer.Dial(u.String(), header)
-
-	if err != nil {
-		if resp != nil {
-			log.Printf("handshake failed with status %s", resp.Status)
+	if creds.ApiKey == "" {
+		if v := os.Getenv("DEEPGRAM_API_KEY"); v != "" {
+			log.Println("DEEPGRAM_API_KEY found")
+			creds.ApiKey = v
+		} else {
+			return nil, errors.New("DEEPGRAM_API_KEY not found")
 		}
-		log.Printf("dial failed:", err)
-		return c, resp, err
 	}
-	return c, resp, nil
+	if callback == nil {
+		log.Printf("NewDeepGramWSClient callback is nil. Using DefaultCallbackHandler.\n")
+		callback = live.NewDefaultCallbackHandler()
+	}
+
+	// init
+	conn := Client{
+		options:  options,
+		creds:    creds,
+		sendBuf:  make(chan []byte, 1),
+		callback: callback,
+		router:   live.New(callback),
+		org:      ctx,
+		retry:    true,
+	}
+	conn.ctx, conn.ctxCancel = context.WithCancel(ctx)
+
+	log.Printf("NewDeepGramWSClient Succeeded\n")
+	return &conn, nil
+}
+
+// Connect performs a websocket connection with "defaultConnectRetry" number of retries.
+func (c *Client) Connect() *websocket.Conn {
+	return c.ConnectWithRetry(defaultConnectRetry)
+}
+
+// AttemptReconnect does exactly that...
+func (c *Client) AttemptReconnect(retries int64) *websocket.Conn {
+	c.retry = true
+	return c.ConnectWithRetry(retries)
+}
+
+// ConnectWithRetry is a function to explicitly do a reconnect
+func (c *Client) ConnectWithRetry(retries int64) *websocket.Conn {
+	// we explicitly stopped and should not attempt to reconnect
+	if !c.retry {
+		log.Printf("This connection has been terminated. Please either call with AttemptReconnect or create a new Client object using NewWebSocketClient.")
+		return nil
+	}
+
+	// if the connection is good, return it
+	// otherwise, attempt reconnect
+	if c.wsconn != nil {
+		select {
+		case <-c.ctx.Done():
+			// continue through to reconnect by recreating the wsconn object
+			// log.Printf("Connection is broken. Will attempt reconnect.")
+			c.ctx, c.ctxCancel = context.WithCancel(c.org)
+		default:
+			// log.Printf("Connection is good. Return object.")
+			return c.wsconn
+		}
+	}
+
+	// TODO: Disable the Hostname validation for now
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 45 * time.Second,
+		TLSClientConfig:  &tls.Config{InsecureSkipVerify: true},
+		RedirectService:  c.creds.RedirectService,
+		SkipServerAuth:   c.creds.SkipServerAuth,
+	}
+
+	// set websocket headers
+	myHeader := http.Header{}
+
+	// restore application options to HTTP header
+	if headers, ok := c.ctx.Value(interfaces.HeadersContext{}).(http.Header); ok {
+		for k, v := range headers {
+			for _, v := range v {
+				log.Printf("Connect() RESTORE Header: %s = %s\n", k, v)
+				myHeader.Add(k, v)
+			}
+		}
+	}
+
+	// sets the API key
+	myHeader.Set("Host", "token "+c.creds.Host)
+	myHeader.Set("Authorization", "token "+c.creds.ApiKey)
+	myHeader.Set("User-Agent", interfaces.DgAgent)
+
+	// attempt to establish connection
+	i := int64(0)
+	for {
+		if retries != connectionRetryInfinite && i >= retries {
+			log.Printf("Connect timeout... exiting!\n")
+			break
+		}
+
+		// delay on subsequent calls
+		if i > 0 {
+			log.Printf("Sleep for retry #%d...\n", i)
+			time.Sleep(time.Second * time.Duration(defaultDelayBetweenRetry))
+		}
+
+		i++
+
+		// create new connection
+		query, _ := query.Values(c.options)
+		u := url.URL{Scheme: "wss", Host: c.creds.Host, Path: "/v1/listen", RawQuery: query.Encode()}
+
+		// TODO: DO NOT PRINT
+		// log.Printf("***REMOVE*** connecting to %s", u.String())
+
+		// c, resp, err := websocket.DefaultDialer.Dial(u.String(), header)
+		ws, _, err := dialer.DialContext(c.ctx, u.String(), myHeader)
+		if err != nil {
+			log.Printf("Cannot connect to websocket: %s\n", u.Host)
+			continue
+		}
+
+		// set the object to allow threads to function
+		log.Printf("WebSocket Connection Successful!")
+		c.wsconn = ws
+		c.retry = true
+
+		// kick off threads
+		go c.listen()
+		go c.ping()
+
+		return c.wsconn
+	}
+
+	return nil
+}
+
+func (c *Client) listen() {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			for {
+				ws := c.Connect()
+				if ws == nil {
+					log.Printf("WebSocketClient::listen: Connection is not valid\n")
+					break
+				}
+
+				msgType, byMsg, err := ws.ReadMessage()
+				if err != nil {
+					log.Printf("WebSocketClient::listen: Cannot read websocket message. Err: %v\n", err)
+					break
+				}
+
+				if len(byMsg) == 0 {
+					log.Printf("WebSocketClient::listen: message empty")
+					continue
+				}
+
+				if c.callback != nil {
+					c.router.Message(byMsg)
+				} else {
+					log.Printf("WebSocketClient::listen: msg recv (type %d): %s\n", msgType, string(byMsg))
+				}
+			}
+		}
+	}
+}
+
+// Stream is a helper function to stream audio data to deepgram
+func (c *Client) Stream(r io.Reader) error {
+	chunk := make([]byte, CHUNK_SIZE)
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return nil
+		default:
+			bytesRead, err := r.Read(chunk)
+			if err != nil {
+				// TODO: must put behind verbosity logging
+				// log.Printf("r.Read failed. Err: %v\n", err)
+				return err
+			}
+
+			if bytesRead == 0 {
+				continue
+			}
+
+			_, err = c.Write(chunk[:bytesRead])
+			if err != nil {
+				log.Printf("w.Write failed. Err: %v\n", err)
+				return err
+			}
+			// log.Printf("io.Writer succeeded. Bytes written: %d\n", byteCount) // TODO: debug only... delete or implement log levels
+		}
+	}
+}
+
+// WriteBinary writes a Go struct to the websocket server
+func (c *Client) WriteBinary(byData []byte) error {
+	// doing a write, need to lock
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ws := c.Connect()
+	if ws == nil {
+		log.Printf("WebSocketClient::WriteBinary Connection is not valid\n")
+		return ErrInvalidConnection
+	}
+
+	if err := ws.WriteMessage(
+		websocket.BinaryMessage,
+		byData,
+	); err != nil {
+		log.Printf("WebSocketClient::WriteBinary WriteMessage failed. Err: %v\n", err)
+		return err
+	}
+
+	// log.Printf("WriteBinary Successful\n") // TODO: debug only... delete or implement log levels
+	// log.Printf("WriteBinary payload:\nData: %x\n", byData) // TODO: debug only... delete or implement log levels
+
+	return nil
+}
+
+// WriteJSON writes a JSON payload to the websocket server
+func (c *Client) WriteJSON(payload interface{}) error {
+	// doing a write, need to lock
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ws := c.Connect()
+	if ws == nil {
+		log.Printf("WebSocketClient::WriteJSON Connection is not valid\n")
+		return ErrInvalidConnection
+	}
+
+	dataStruct, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("WebSocketClient::WriteJSON json.Marshal failed. Err: %v\n", err)
+		return err
+	}
+
+	if err := ws.WriteMessage(
+		websocket.TextMessage,
+		dataStruct,
+	); err != nil {
+		log.Printf("WebSocketClient::WriteJSON WriteMessage failed. Err: %v\n", err)
+		return err
+	}
+
+	// log.Printf("WriteJSON Successful\n") // TODO: debug only... delete or implement log levels
+	// log.Printf("WriteJSON payload:\nData: %s\n", string(dataStruct)) // TODO: debug only... delete or implement log levels
+
+	return nil
+}
+
+// Write performs the lower level websocket write operation
+func (c *Client) Write(p []byte) (int, error) {
+	byteLen := len(p)
+	err := c.WriteBinary(p)
+	if err != nil {
+		log.Printf("WebSocketClient::WriteBinary failed. Err: %v\n", err)
+		return 0, err
+	}
+	return byteLen, nil
+}
+
+// Stop will send close message and shutdown websocket connection
+func (c *Client) Stop() {
+	log.Printf("WebSocketClient::Stop Stopping...\n")
+	c.ctxCancel()
+	c.closeWs()
+}
+
+func (c *Client) closeWs() {
+	log.Printf("WebSocketClient::closeWs closing channels...\n")
+
+	// doing a write, need to lock
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.wsconn != nil {
+		// deepgram requires a close message to be sent
+		errDg := c.wsconn.WriteMessage(websocket.TextMessage, []byte("{ \"type\": \"CloseStream\" }"))
+		if errDg != nil {
+			log.Printf("Failed to send CloseNormalClosure. Err: %v\n", errDg)
+		}
+		time.Sleep(TERMINATION_SLEEP) // allow time for server to register closure
+
+		// protocol message
+		errProto := c.wsconn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		if errProto != nil {
+			log.Printf("Failed to send CloseNormalClosure. Err: %v\n", errProto)
+		}
+		time.Sleep(TERMINATION_SLEEP) // allow time for server to register closure
+		c.wsconn.Close()
+	}
+}
+
+func (c *Client) ping() {
+	log.Printf("WebSocketClient::ping ENTER\n")
+
+	ticker := time.NewTicker(pingPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		case <-ticker.C:
+			log.Printf("Starting ping...")
+
+			ws := c.Connect()
+			if ws == nil {
+				log.Printf("WebSocketClient::ping Connect is not valid\n")
+				break
+			}
+
+			// doing a write, need to lock
+			c.mu.Lock()
+			log.Printf("Sending ping... need reply in %d\n", (pingPeriod / 2))
+
+			// deepgram keepalive
+			errDg := ws.WriteMessage(websocket.BinaryMessage, []byte("{ \"type\": \"KeepAlive\" }"))
+			if errDg != nil {
+				log.Printf("Failed to send CloseNormalClosure. Err: %v\n", errDg)
+			}
+
+			// protocol ping/pong
+			errProto := ws.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(pingPeriod/2))
+			if errProto != nil {
+				log.Printf("Failed to send CloseNormalClosure. Err: %v\n", errProto)
+			}
+			c.mu.Unlock()
+
+			if errDg != nil || errProto != nil {
+				log.Printf("WebSocketClient::ping failed\n")
+				c.closeWs()
+			} else {
+				log.Printf("Ping sent!")
+			}
+		}
+	}
 }

--- a/pkg/client/live/constants.go
+++ b/pkg/client/live/constants.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+package live
+
+import (
+	"errors"
+	"time"
+	// gabs "github.com/Jeffail/gabs/v2"
+)
+
+const (
+	pingPeriod = 30 * time.Second
+
+	connectionRetryInfinite  int64 = 0
+	defaultConnectRetry      int64 = 3
+	defaultDelayBetweenRetry int64 = 2
+
+	CHUNK_SIZE        = 1024 * 2
+	TERMINATION_SLEEP = 100 * time.Millisecond
+)
+
+var (
+	// ErrInvalidConnection connection is not valid
+	ErrInvalidConnection = errors.New("connection is not valid")
+)

--- a/pkg/client/live/types.go
+++ b/pkg/client/live/types.go
@@ -1,0 +1,38 @@
+package live
+
+import (
+	"context"
+	"sync"
+
+	"github.com/dvonthenen/websocket"
+
+	live "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1"
+	msginterface "github.com/deepgram-devs/deepgram-go-sdk/pkg/api/live/v1/interfaces"
+	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+)
+
+// Credentials for connecting to the platform
+type Credentials struct {
+	Host            string
+	ApiKey          string
+	RedirectService bool
+	SkipServerAuth  bool
+}
+
+// Client return websocket client connection
+type Client struct {
+	options interfaces.LiveTranscriptionOptions
+
+	sendBuf   chan []byte
+	org       context.Context
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	mu     sync.RWMutex
+	wsconn *websocket.Conn
+	retry  bool
+
+	creds    *Credentials
+	callback msginterface.LiveMessageCallback
+	router   *live.MessageRouter
+}


### PR DESCRIPTION
## Proposed changes

**NOTE:** This depends on https://github.com/deepgram-devs/deepgram-go-sdk/pull/86 and https://github.com/deepgram-devs/deepgram-go-sdk/pull/87 and is targeted to `go-sdk-v1` release. Will rebase when https://github.com/deepgram-devs/deepgram-go-sdk/pull/86 and https://github.com/deepgram-devs/deepgram-go-sdk/pull/87 are merged. The diff in this PR will look pretty nasty until subsequent depend PRs are merged first. Until these get merged, here is a better looking diff to track the changes between branches: https://github.com/dvonthenen/deepgram-go-sdk/compare/dv/update-headers-with-licensing...dvonthenen:deepgram-go-sdk:dv/live-streaming-object-definition

Addresses https://github.com/deepgram-devs/deepgram-go-sdk/issues/89 and https://github.com/deepgram-devs/deepgram-go-sdk/issues/35. Implements more of an object-oriented approach to handling the live stream struct. This change implements the following:
- A streaming `io.Closer` interface so that you can stream data to Live Client. This is super helpful so you don't need to expose or manipulate reading/writing buffers. A callback interface is defined such that you receive a MessageResponse struct each time data is sent from the DG Platform to the client.
- Implements Keep-Alive capabilities to the Live Client for when data is not sent to the DG Platform. This is done at:
  - the Deepgram platform level
  - and also at the websocket protocol level
- Requires a Go `context` to be passed into the Live Client creation. This is to facilitate:
  - Controlled `Close` and `Cancel` of the websocket
  - Automatic retry capabilities when socket abnormally closes
- The `examples/streaming` has been updated to show how to use the client
- Implements a clear separation of the websocket client `pkg/client/live` and the Deepgram protocol for interacting with the service `pkg/api/live/v1`.

Instead of doing buffer reading and writing, this is what the example looks like now:

```go
func main() {
	// context
	ctx := context.Background()

	// options
	transcriptOptions := interfaces.LiveTranscriptionOptions{
		Language:  "en-US",
		Punctuate: true,
	}

	dgClient, err := client.NewWithDefaults(ctx, transcriptOptions)
	if err != nil {
		log.Println("ERROR creating LiveTranscription connection:", err)
		return
	}

	// call connect!
	wsconn := dgClient.Connect()
	if wsconn == nil {
		log.Println("Client.Connect failed")
		os.Exit(1)
	}

	// create the HTTP stream
	httpClient := new(http.Client)

	res, err := httpClient.Get(STREAM_URL)
	if err != nil {
		log.Printf("httpClient.Get failed. Err: %v\n", err)
		return
	}

	fmt.Printf("Stream is up and running %s\n", reflect.TypeOf(res))

	// feed the stream to the websocket. this is a blocking call!
	go func() {
		dgClient.Stream(bufio.NewReader(res.Body))
	}()

	fmt.Print("Press ENTER to exit!\n\n")
	input := bufio.NewScanner(os.Stdin)
	input.Scan()

	// close HTTP stream
	res.Body.Close()

	// close client
	dgClient.Stop()

	fmt.Printf("Succeeded!\n\n")
}
```

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

PR https://github.com/deepgram-devs/deepgram-go-sdk/pull/86 handled the restructure of the project. This is the first PR to start refactoring and improving individual components in this new restructure. This PR handles just the Live Client and Live Client only. I am trying to reduce the amount of code change in this PR and each component will be handled one at a time.

Will squash the commits after the review is completed.