### PR TITLE
Implements the Prerecorded Refactor for Upcoming REST/HTTP `Manage API` Client Changes

### DIFF
--- a/examples/prerecorded/main.go
+++ b/examples/prerecorded/main.go
@@ -20,25 +20,18 @@ import (
 )
 
 func main() {
-	var deepgramApiKey string
-	if v := os.Getenv("DEEPGRAM_API_KEY"); v != "" {
-		log.Println("DEEPGRAM_API_KEY found")
-		deepgramApiKey = v
-	} else {
-		log.Fatal("DEEPGRAM_API_KEY not found")
-		os.Exit(1)
-	}
-
 	// context
 	ctx := context.Background()
 
-	c := client.New(deepgramApiKey)
+	//client
+	c := client.NewWithDefaults()
 	dg := prerecorded.New(c)
 
 	filePath := "https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"
 	var res interface{}
 	var err error
 
+	// send stream
 	if isURL(filePath) {
 		res, err = dg.FromURL(
 			ctx,

--- a/pkg/client/interfaces/types-prerecorded.go
+++ b/pkg/client/interfaces/types-prerecorded.go
@@ -2,14 +2,19 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+/*
+This package contains the interface to manage the prerecorded interfaces for the Deepgram API
+*/
 package interfaces
 
-type PreRecordedTranscriptionOptions struct {
-	// internal
-	Host       string `url:"-"`
-	ApiVersion string `url:"-"`
+/*
+PreRecordedTranscriptionOptions contain all of the knobs and dials to control a Prerecorded transcription
+from the Deepgram API
 
-	// live options
+Please see the documentation for live/streaming for more details:
+https://developers.deepgram.com/reference/pre-recorded
+*/
+type PreRecordedTranscriptionOptions struct {
 	Alternatives       int         `json:"alternatives" url:"alternatives,omitempty" `
 	AnalyzeSentiment   bool        `json:"analyze_sentiment" url:"analyze_sentiment,omitempty" `
 	Callback           string      `json:"callback" url:"callback,omitempty" `

--- a/pkg/client/live/client.go
+++ b/pkg/client/live/client.go
@@ -28,7 +28,7 @@ import (
 )
 
 /*
-NewWithDefaults() creates a new websocket connection with all default options
+NewWithDefaults creates a new websocket connection with all default options
 
 Notes:
   - The Deepgram API KEY is read from the environment variable DEEPGRAM_API_KEY
@@ -39,7 +39,7 @@ func NewWithDefaults(ctx context.Context, apiKey string, options interfaces.Live
 }
 
 /*
-New() creates a new websocket connection with the specified options
+New creates a new websocket connection with the specified options
 
 Input parameters:
 - ctx: context.Context object

--- a/pkg/client/prerecorded/types.go
+++ b/pkg/client/prerecorded/types.go
@@ -8,7 +8,15 @@ import (
 	rest "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/rest"
 )
 
+// ClientOptions defines any options for the client
+type ClientOptions struct {
+	Host    string
+	Version string
+}
+
 // Client implements helper functionality for Prerecorded API
 type Client struct {
 	*rest.Client
+
+	apiKey string
 }

--- a/pkg/client/rest/rest.go
+++ b/pkg/client/rest/rest.go
@@ -15,10 +15,18 @@ import (
 	"os"
 
 	interfaces "github.com/deepgram-devs/deepgram-go-sdk/pkg/client/interfaces"
+	common "github.com/deepgram-devs/deepgram-go-sdk/pkg/common"
 )
 
+func NewWithDefaults() *Client {
+	return New("", &ClientOptions{})
+}
+
 // New allocated a REST client
-func New(apiKey string) *Client {
+func New(apiKey string, options *ClientOptions) *Client {
+	if options.Host == "" {
+		options.Host = common.DefaultHost
+	}
 	if apiKey == "" {
 		if v := os.Getenv("DEEPGRAM_API_KEY"); v != "" {
 			log.Println("DEEPGRAM_API_KEY found")
@@ -31,7 +39,8 @@ func New(apiKey string) *Client {
 
 	c := Client{
 		HttpClient: NewHTTPClient(),
-		ApiKey:     apiKey,
+		Options:    options,
+		apiKey:     apiKey,
 	}
 	return &c
 }
@@ -51,7 +60,7 @@ func (c *Client) Do(ctx context.Context, req *http.Request, resBody interface{})
 
 	// req.Header.Set("Host", c.options.Host)
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Authorization", "token "+c.ApiKey)
+	req.Header.Set("Authorization", "token "+c.apiKey)
 	req.Header.Set("User-Agent", interfaces.DgAgent)
 
 	switch req.Method {

--- a/pkg/client/rest/types.go
+++ b/pkg/client/rest/types.go
@@ -8,6 +8,12 @@ import (
 	"net/http"
 )
 
+// ClientOptions defines any options for the client
+type ClientOptions struct {
+	Host    string
+	Version string
+}
+
 // HttpClient which extends HTTP client
 type HttpClient struct {
 	http.Client
@@ -20,5 +26,6 @@ type HttpClient struct {
 type Client struct {
 	*HttpClient
 
-	ApiKey string
+	Options *ClientOptions
+	apiKey  string
 }

--- a/tests/prerecorded_test.go
+++ b/tests/prerecorded_test.go
@@ -124,7 +124,7 @@ func TestPrerecordedFromURL(t *testing.T) {
 	httpmock.RegisterResponder("POST", betaEndPoint, preRecordedFromURLHandler)
 
 	t.Run("Test Basic PreRecordedFromURL", func(t *testing.T) {
-		c := client.New(MockAPIKey)
+		c := client.New(MockAPIKey, &client.ClientOptions{})
 		httpmock.ActivateNonDefault(&c.Client.HttpClient.Client)
 		dg := prerecorded.New(c)
 		_, err := dg.FromURL(
@@ -138,7 +138,7 @@ func TestPrerecordedFromURL(t *testing.T) {
 	})
 
 	t.Run("Test PreRecordedFromURL with summarize v1", func(t *testing.T) {
-		c := client.New(MockAPIKey)
+		c := client.New(MockAPIKey, &client.ClientOptions{})
 		httpmock.ActivateNonDefault(&c.Client.HttpClient.Client)
 		dg := prerecorded.New(c)
 		_, err := dg.FromURL(
@@ -154,7 +154,7 @@ func TestPrerecordedFromURL(t *testing.T) {
 	})
 
 	t.Run("Test PreRecordedFromURL with summarize v2", func(t *testing.T) {
-		c := client.New(MockAPIKey)
+		c := client.New(MockAPIKey, &client.ClientOptions{})
 		httpmock.ActivateNonDefault(&c.Client.HttpClient.Client)
 		dg := prerecorded.New(c)
 		_, err := dg.FromURL(


### PR DESCRIPTION
## Proposed changes

Depends on PR https://github.com/deepgram-devs/deepgram-go-sdk/pull/108

Here is a clean diff between the dependent branch:
https://github.com/dvonthenen/deepgram-go-sdk/compare/dv/refactor-rest-client...dvonthenen:deepgram-go-sdk:dv/refactor-rest-prerecorded-client

This handles a refactor of the Prerecorded client after taking into account changes in the HTTP/REST changes for the `Manage API` changes. This is just to give a consistent look-and-feel for changes coming to HTTP/REST plumbing.

Changes include:
- fixes `examples/prerecorded` with the new ClientOptions on the Prerecorded Client
- changes to `version.GetPrerecordedAPI` which allows defaults and overrides for the URL for the prerecorded endpoint

## Types of changes

What types of changes does your code introduce to the community Go SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

NA